### PR TITLE
Add setup documentation for linux/mac developers

### DIFF
--- a/docs/technical/setup-local-dev-env.md
+++ b/docs/technical/setup-local-dev-env.md
@@ -1,23 +1,36 @@
 ## Setting up local development environment
 
 ### Prerequisite Technology Installs
+
+**For full installation instructions please refer to the `Installation Guide` which includes nuances for each OS distribution**
+
+#### OS Software Managers
 - Chocolatey
   * Windows software manager - think of it like NuGet but for Windows software
   * Setup guide: https://docs.chocolatey.org/en-us/choco/setup
+- Homebrew
+  * Mac software manager
+  * Setup guide: https://docs.brew.sh/Installation.html
+
+#### Software Tools
 - Azure CLI 
   * A cross-platform command-line tool to connect to Azure and execute administrative commands on Azure resource
   * Installation Guide: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
   * Chocolatey Command: `choco install azure-cli`
+  * Homebrew Command: `brew update && brew install azure-cli`
 - Terraform
   * Infrastructure as Code (IaC) tool
   * Installation Guide: https://learn.hashicorp.com/tutorials/terraform/install-cli
-  * Chocolatey Command recommended: `choco install terraform`
+  * Chocolatey Command: `choco install terraform`
+  * Homebrew Command: `brew tap hashicorp/tap` `brew install hashicorp/tap/terraform`
 - Terraform Extension (only if using VS Code)
   * VS Code extension to help with syntax highlighting, IntelliSense, code navigation, code formatting, module explorer, etc.
   * Installation Guide: https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform
 - Make
   * A tool to define a set of steps 
   * Chocolatey Command: `choco install make`
+  * Homebrew Command: `brew install make`
+  * Unix/Linux: `make` is part of the default distribution
 
 ### Creating a service principal
 1. Sign in to your Azure Account through the Azure portal

--- a/docs/technical/setup-local-dev-env.md
+++ b/docs/technical/setup-local-dev-env.md
@@ -1,6 +1,6 @@
-# Setting up local development environment
+## Setting up local development environment
 
-Prerequisite Technology Installs
+### Prerequisite Technology Installs
 - Chocolatey
   * Windows software manager - think of it like NuGet but for Windows software
   * Setup guide: https://docs.chocolatey.org/en-us/choco/setup
@@ -19,7 +19,7 @@ Prerequisite Technology Installs
   * A tool to define a set of steps 
   * Chocolatey Command: `choco install make`
 
-Creating a service principal
+### Creating a service principal
 1. Sign in to your Azure Account through the Azure portal
 2. Select `Azure Active Directory`
 3. Select `App registrations`
@@ -27,20 +27,20 @@ Creating a service principal
 5. Enter a suitable app name
 6. Click `Register`
 
-Creating a client secret for the service principal
+### Creating a client secret for the service principal
 1. In AAD select your service principal
 2. On the left hand side select `Certificates and secrets`
 3. Click `+ New client secret`
 4. Copy and save the `value` - this will be need to authenticate
 
-Giving permission to your service principal
+### Giving permission to your service principal
 1. On the Subscription page go to `Access Control (IAM)`
 2. Select `Add role assignment`
 3. Select `Contributor`
 4. Select `select members` and search for the name of your recently created service principal
 5. Select `Review + Assign`
 
-Updating local credentials.tfvars file
+### Updating local credentials.tfvars file
 1. Copy and rename the `credentials-template.tfvars` file and name it `credentials.tfvars`
 2. Fill in the values using the following information from your previously created service principal
     - `client_id` = Object ID of the service principal
@@ -48,6 +48,6 @@ Updating local credentials.tfvars file
     - `tenent_id` = Directory (tenent) ID of the service principal
     - `subscription_id` = Subscription ID of the subscription
  
-Deploying the infrastructure locally
+### Deploying the infrastructure locally
 1. Ensure that you have `make` installed and are in the terraform directory
 2. In the terminal run `make tf-deploy` - this will verify the terraform and deploy to your specified subscription

--- a/docs/technical/setup-local-dev-env.md
+++ b/docs/technical/setup-local-dev-env.md
@@ -47,6 +47,8 @@
     - `client_secret` = The secret created for the service principal
     - `tenent_id` = Directory (tenent) ID of the service principal
     - `subscription_id` = Subscription ID of the subscription
+    - `environment_name` = Unique name used to create resource names
+    - `environment_postfix` = An identifier (usually an integer) to help distinguish deployments
  
 ### Deploying the infrastructure locally
 1. Ensure that you have `make` installed and are in the terraform directory


### PR DESCRIPTION
Added basic brew install instructions for Mac, included link to full installation guide for each tool for reference for specific OS distributions

AC:
 - Should have linux/mac friendly instructions to tool installations.
   * Added homebrew installation guide reference
   * Added homebrew commands for key software tools
 - Should have markdown heading styles on some section headers to aid readability.
   * Added more markdown headers, and utilised bold text to emphasise key info
 