### PR TITLE
Add dev and prod jobs

### DIFF
--- a/.github/workflows/cd-infrastructure-pr.yml
+++ b/.github/workflows/cd-infrastructure-pr.yml
@@ -1,0 +1,24 @@
+name: Infrastructure_cd
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths: ['.github/workflows/cd-infrastructure-*','.github/workflows/reusable-terraform-deployment','infrastructure/**']
+    types: [opened, synchronize, closed]
+
+jobs:
+  Pr_deployment:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    uses: ./.github/workflows/reusable-terraform-deployment.yml
+    with:
+      gh_environment: PR
+      working_directory_path: infrastructure
+      environment_name: pr
+      environment_postfix: ${{ github.event.number }}
+    secrets:
+      azure_ad_client_id: ${{ secrets.AZURE_AD_CLIENT_ID }}
+      azure_ad_client_secret: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
+      azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}

--- a/.github/workflows/cd-infrastructure-release.yml
+++ b/.github/workflows/cd-infrastructure-release.yml
@@ -4,33 +4,10 @@ on:
   push:
     branches:
       - main
-    paths: ['.github/workflows/**','infrastructure/**']
-  pull_request:
-    branches:
-      - main
-    paths: ['.github/workflows/**','infrastructure/**']
-    types: [opened, synchronize, closed]
-
-env:
-  IS_MAIN_BRANCH: github.event_name == 'push' && github.ref_name == 'main'
+    paths: ['.github/workflows/cd-infrastructure-*','.github/workflows/reusable-terraform-deployment','infrastructure/**']
 
 jobs:
-  Pr_deployment:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    uses: ./.github/workflows/reusable-terraform-deployment.yml
-    with:
-      gh_environment: PR
-      working_directory_path: infrastructure
-      environment_name: pr
-      environment_postfix: ${{ github.event.number }}
-    secrets:
-      azure_ad_client_id: ${{ secrets.AZURE_AD_CLIENT_ID }}
-      azure_ad_client_secret: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
-      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
-      azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
   Dev_deployment:
-    if: github.event.pull_request.merged == true
     uses: ./.github/workflows/reusable-terraform-deployment.yml
     with:
       gh_environment: Development

--- a/.github/workflows/cd-infrastructure.yml
+++ b/.github/workflows/cd-infrastructure.yml
@@ -30,7 +30,7 @@ jobs:
       azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
       azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
   Dev_deployment:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     uses: ./.github/workflows/reusable-terraform-deployment.yml
     with:
       gh_environment: Development

--- a/.github/workflows/cd-infrastructure.yml
+++ b/.github/workflows/cd-infrastructure.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   Pr_deployment:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     uses: ./.github/workflows/reusable-terraform-deployment.yml
     with:
       gh_environment: PR
@@ -44,7 +44,6 @@ jobs:
       azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
       azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
   Prod_deployment:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     needs: Dev_deployment
     uses: ./.github/workflows/reusable-terraform-deployment.yml
     with:

--- a/.github/workflows/cd-infrastructure.yml
+++ b/.github/workflows/cd-infrastructure.yml
@@ -36,7 +36,6 @@ jobs:
       gh_environment: Development
       working_directory_path: infrastructure
       environment_name: dev
-      environment_postfix: ${{ github.event.number }}
     secrets:
       azure_ad_client_id: ${{ secrets.AZURE_AD_CLIENT_ID }}
       azure_ad_client_secret: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
@@ -50,7 +49,6 @@ jobs:
       gh_environment: Production
       working_directory_path: infrastructure
       environment_name: prod
-      environment_postfix: ${{ github.event.number }}
     secrets:
       azure_ad_client_id: ${{ secrets.AZURE_AD_CLIENT_ID }}
       azure_ad_client_secret: ${{ secrets.AZURE_AD_CLIENT_SECRET }}

--- a/.github/workflows/cd-infrastructure.yml
+++ b/.github/workflows/cd-infrastructure.yml
@@ -28,3 +28,32 @@ jobs:
       azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
       azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+  Dev_deployment:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    uses: ./.github/workflows/reusable-terraform-deployment.yml
+    with:
+      gh_environment: Development
+      working_directory_path: infrastructure
+      environment_name: dev
+      environment_postfix: ${{ github.event.number }}
+    secrets:
+      azure_ad_client_id: ${{ secrets.AZURE_AD_CLIENT_ID }}
+      azure_ad_client_secret: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
+      azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+  Prod_deployment:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    needs: Dev_deployment
+    uses: ./.github/workflows/reusable-terraform-deployment.yml
+    with:
+      gh_environment: Production
+      working_directory_path: infrastructure
+      environment_name: prod
+      environment_postfix: ${{ github.event.number }}
+    secrets:
+      azure_ad_client_id: ${{ secrets.AZURE_AD_CLIENT_ID }}
+      azure_ad_client_secret: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure_ad_tenant_id: ${{ secrets.AZURE_AD_TENANT_ID }}
+      azure_storage_account_key: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}

--- a/.github/workflows/cd-infrastructure.yml
+++ b/.github/workflows/cd-infrastructure.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
     paths: ['.github/workflows/**','infrastructure/**']
+    types: [opened, synchronize, closed]
 
 env:
   IS_MAIN_BRANCH: github.event_name == 'push' && github.ref_name == 'main'


### PR DESCRIPTION
Two extra jobs have been added to provision a development and production environment.

~~The current logic works as follows:~~
~~- PR opened -> `Pr_deployment` job runs~~
~~- PR synchronised (e.g. push to branch with open PR) -> `Pr_deployment` job runs~~
~~- PR closed but not merged -> no workflows run~~
~~- PR merged -> `Pr_deployment` job doesn't run, `Dev_deployment` job runs and if successful then `Prod_deployment` job runs~~

The new logic works as follows:
- PR opened/synchronised (e.g. push to branch with open PR) - `cd-infrastructure-pr` workflow runs
- PR closed but not merged -> no workflows run
- Push to `main` (PR merged) -> `cd-infrastructure-release` workflow runs

*note: a new repository environment has been set up called `Production`, both `Development` and `Production` environments have had protection rules applied so that only the `main` branch can deploy to them*

*note note: this has been tested in a separate repo in order to test merge to main functionality*

Acceptance Criteria
- Should trigger workflow on merging to main
  * the `Dev_deployment` job in the `cd-infrastructure-release` workflow can be triggered manually or by push to main branch
- Should provision main branch changes into dev environment
  * Only provisions main branch changes on push to main
- Should provision prod environment, if dev environment job completed successfully
  * Added `needs: Dev_deployment` to `Prod_deployment`