### PR TITLE
adding in appsettings for each app

### DIFF
--- a/helm-charts/dmr/values.yaml
+++ b/helm-charts/dmr/values.yaml
@@ -78,11 +78,9 @@ appSettings:
   # appsettings.json file (.Net), double underscore (__) correspond to a nested field e.g.
   # '"object" : { "key": "value" }' is equivalent to 'object__key: value'
   MOCKCENTOPS__CHATBOTS__0__ID: bot1
-  MOCKCENTOPS__CHATBOTS__0__ENDPOINT: http://bot2/dmr-api/messages
-  MOCKCENTOPS__CHATBOTS__1__ID: bot2
-  MOCKCENTOPS__CHATBOTS__1__ENDPOINT: http://bot2/dmr-api/messages
-  DMRSERVICESETTINGS__CLASSIFIERURI: http://classifier/dmr-api/messages
-  DMRSERVICESETTINGS__CENTOPSURI: http://centops
+  MOCKCENTOPS__CHATBOTS__0__ENDPOINT: http://mock-bot-service.applications.svc.cluster.local/dmr-api/messages
+  DMRSERVICESETTINGS__CLASSIFIERURI: http://mock-classifier-service.applications.svc.cluster.local/dmr-api/messages
+  DMRSERVICESETTINGS__CENTOPSURI: http://centops-service.applications.svc.cluster.local
   
 appSecrets:
   # PLEASE DO NOT LIST ANY APP SECRETS HERE! THIS IS A PUBLIC REPO, HARDCODED SECRETS CAN BE PUBLICLY READ

--- a/helm-charts/mock-bot/values.yaml
+++ b/helm-charts/mock-bot/values.yaml
@@ -77,6 +77,9 @@ appSettings:
   # Please place any non-secret app settings/config values here, these correspond to the values in the
   # appsettings.json file (.Net), double underscore (__) correspond to a nested field e.g.
   # '"object" : { "key": "value" }' is equivalent to 'object__key: value'
+  DMRSERVICESETTINGS__DMRAPIURI: http://dmr-service.applications.svc.cluster.local
+  DMRSERVICESETTINGS__DMRREQUESTPROCESSINTERVALMS: 5000
+  BOTSETTINGS__ID: MockBot
   
 appSecrets:
   # PLEASE DO NOT LIST ANY APP SECRETS HERE! THIS IS A PUBLIC REPO, HARDCODED SECRETS CAN BE PUBLICLY READ

--- a/helm-charts/mock-classifier/values.yaml
+++ b/helm-charts/mock-classifier/values.yaml
@@ -77,6 +77,8 @@ appSettings:
   # Please place any non-secret app settings/config values here, these correspond to the values in the
   # appsettings.json file (.Net), double underscore (__) correspond to a nested field e.g.
   # '"object" : { "key": "value" }' is equivalent to 'object__key: value'
+  DMRSERVICESETTINGS__DMRAPIURI: http://dmr-service.applications.svc.cluster.local
+  DMRSERVICESETTINGS__DMRREQUESTPROCESSINTERVALMS: 5000
   
 appSecrets:
   # PLEASE DO NOT LIST ANY APP SECRETS HERE! THIS IS A PUBLIC REPO, HARDCODED SECRETS CAN BE PUBLICLY READ


### PR DESCRIPTION
This PR addresses the following issue(s):

1. Adding in the correct appsettings to represent the actual context e.g., correct dmr uri for centops API
2. This is for the DMR/Mock-bot/Mock-classifier only 