### PR TITLE
Add ingress values into MockBot and MockClassifier helm

### DIFF
--- a/helm-charts/mock-bot/values.yaml
+++ b/helm-charts/mock-bot/values.yaml
@@ -31,6 +31,9 @@ service:
   type: ClusterIP
   port: 80
 
+ingress:
+  host: ""
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/helm-charts/mock-classifier/values.yaml
+++ b/helm-charts/mock-classifier/values.yaml
@@ -31,6 +31,9 @@ service:
   type: ClusterIP
   port: 80
 
+ingress:
+  host: ""
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR adds the missing ingress properties for the MockBot and MockClassifier helm charts.   The `ingress.host` value is already being fed in by the deployment pipeline, but was not declared in in their value.yaml files causing a helm linting error.

See deployments for both applications here: https://github.com/buerokratt/Infrastructure/runs/7386131331